### PR TITLE
Pydantic v2 makes rhnode break. Forced to be v1 here

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 uvicorn
 requests
 jinja2
-pydantic
+pydantic<2
 fastapi
 python-multipart
 fastapi-utils


### PR DESCRIPTION
As title says. For pydantic >=2.0 there is a number of places we need to update. See: https://docs.pydantic.dev/latest/migration/

Without updating we get the error:

```
if issubclass(field.type_, FilePath):
nnunet-1         | AttributeError: 'FieldInfo' object has no attribute 'type_'
```

